### PR TITLE
[design] 뉴스레터 조회 페이지 마크업

### DIFF
--- a/src/app/(user)/newsletter/[id]/page.tsx
+++ b/src/app/(user)/newsletter/[id]/page.tsx
@@ -2,12 +2,29 @@
 
 import { useParams } from 'next/navigation';
 import React from 'react';
+import { data } from '../page';
 
 function NewsLetterDetailPage() {
     const params = useParams();
     const newsId = params.id;
+    const news = data.find(item => item.news_id === newsId);
 
-    return <div>news_id : {newsId}</div>;
+    return (
+        <div>
+            <div className="text-s">{news?.user_name}</div>
+            <div className="text-l font-bold">{news?.title}</div>
+            {news?.img_url && (
+                <div className="my-4 w-full h-[350px] overflow-hidden flex items-center justify-center">
+                    <img
+                        src={news.img_url}
+                        alt="뉴스이미지"
+                        className="w-full h-full object-cover object-center"
+                    />
+                </div>
+            )}
+            <div className="">{news?.contents}</div>
+        </div>
+    );
 }
 
 export default NewsLetterDetailPage;

--- a/src/app/(user)/newsletter/[id]/page.tsx
+++ b/src/app/(user)/newsletter/[id]/page.tsx
@@ -9,9 +9,36 @@ function NewsLetterDetailPage() {
     const newsId = params.id;
     const news = data.find(item => item.news_id === newsId);
 
+    const formatRelativeTime = (timestamp?: string) => {
+        if (!timestamp) return '';
+        const now = new Date();
+        const time = new Date(timestamp);
+        const diffInSeconds = Math.floor((now.getTime() - time.getTime()) / 1000); // 초 단위 차이 계산
+
+        if (diffInSeconds < 60) {
+            return `${diffInSeconds}초 전`;
+        }
+
+        const diffInMinutes = Math.floor(diffInSeconds / 60);
+        if (diffInMinutes < 60) {
+            return `${diffInMinutes}분 전`;
+        }
+
+        const diffInHours = Math.floor(diffInMinutes / 60);
+        if (diffInHours < 24) {
+            return `${diffInHours}시간 전`;
+        }
+
+        const diffInDays = Math.floor(diffInHours / 24);
+        return `${diffInDays}일 전`;
+    };
+
     return (
         <div>
-            <div className="text-s">{news?.user_name}</div>
+            <div className="text-s flex gap-4">
+                <div>{news?.user_name}</div>
+                <div className="text-dot-gray-light">{formatRelativeTime(news?.created_at)}</div>
+            </div>
             <div className="text-l font-bold">{news?.title}</div>
             {news?.img_url && (
                 <div className="my-4 w-full h-[350px] overflow-hidden flex items-center justify-center">

--- a/src/app/(user)/newsletter/[id]/page.tsx
+++ b/src/app/(user)/newsletter/[id]/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import React from 'react';
+
+function NewsLetterDetailPage() {
+    const params = useParams();
+    const newsId = params.id;
+
+    return <div>news_id : {newsId}</div>;
+}
+
+export default NewsLetterDetailPage;

--- a/src/app/(user)/newsletter/[id]/page.tsx
+++ b/src/app/(user)/newsletter/[id]/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import React from 'react';
+import React, { useState } from 'react';
+import { Heart, Bookmark, Share } from 'lucide-react';
 import { data } from '../page';
 
 function NewsLetterDetailPage() {
     const params = useParams();
     const newsId = params.id;
     const news = data.find(item => item.news_id === newsId);
+    const [isLiked] = useState(false);
+    const [isBookmarked] = useState(false);
 
     const formatRelativeTime = (timestamp?: string) => {
         if (!timestamp) return '';
@@ -33,6 +36,18 @@ function NewsLetterDetailPage() {
         return `${diffInDays}일 전`;
     };
 
+    const onClickLikeBtn = () => {
+        console.log('like');
+    };
+
+    const onClickBookmarkBtn = () => {
+        console.log('bookmark');
+    };
+
+    const onClickShareBtn = () => {
+        console.log('share');
+    };
+
     return (
         <div>
             <div className="text-s flex gap-4">
@@ -50,6 +65,26 @@ function NewsLetterDetailPage() {
                 </div>
             )}
             <div className="">{news?.contents}</div>
+            <div className="flex justify-evenly my-4">
+                <div className="flex flex-col items-center text-secondary">
+                    <button type="button" onClick={onClickLikeBtn} className="outline-none">
+                        <Heart className={`${isLiked ? 'fill-current' : ''}`} />
+                    </button>
+                    <div>0</div>
+                </div>
+                <div className="flex flex-col items-center text-secondary">
+                    <button type="button" onClick={onClickBookmarkBtn} className="outline-none">
+                        <Bookmark className={`${isBookmarked ? 'fill-current' : ''}`} />
+                    </button>
+                    <div>0</div>
+                </div>
+                <div className="flex flex-col items-center text-secondary">
+                    <button type="button" onClick={onClickShareBtn} className="outline-none">
+                        <Share />
+                    </button>
+                    <div>0</div>
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/app/(user)/newsletter/page.tsx
+++ b/src/app/(user)/newsletter/page.tsx
@@ -127,47 +127,54 @@ function NewsLetterPage() {
                     ))}
                 </ul>
             </div>
-            <div id="newContentsWrap" className="mt-4 flex flex-wrap">
-                {listData.map(news => (
-                    <div
-                        key={news.news_id}
-                        className="w-full pb-4 mb-4 border-b border-area-gray flex justify-between h-[150px]"
-                    >
+            {listData && (
+                <div id="newContentsWrap" className="mt-4 flex flex-wrap">
+                    {listData.map(news => (
                         <div
-                            id="newsText"
-                            className={`${news.img_url ? 'w-4/5' : 'w-full'} flex flex-col justify-around`}
+                            key={news.news_id}
+                            className="w-full pb-4 mb-4 border-b border-area-gray flex justify-between h-[150px]"
                         >
-                            <div id="newsSource" className="text-xs text-dot-gray-dark">
-                                {news.user_name}
-                            </div>
-                            <div id="newsTitle" className="font-bold">
-                                {news.title}
-                            </div>
                             <div
-                                id="newsContents"
-                                className="text-s text-dot-gray-dark2 line-clamp-2"
+                                id="newsText"
+                                className={`${news.img_url ? 'w-4/5' : 'w-full'} flex flex-col justify-around`}
                             >
-                                {news.contents}
+                                <div id="newsSource" className="text-xs text-dot-gray-dark">
+                                    {news.user_name}
+                                </div>
+                                <div id="newsTitle" className="font-bold">
+                                    {news.title}
+                                </div>
+                                <div
+                                    id="newsContents"
+                                    className="text-s text-dot-gray-dark2 line-clamp-2"
+                                >
+                                    {news.contents}
+                                </div>
+                                <div id="newsBottomWrap" className="text-s text-dot-gray-dark">
+                                    <div id="newsDate">{news.created_at}</div>
+                                </div>
                             </div>
-                            <div id="newsBottomWrap" className="text-s text-dot-gray-dark">
-                                <div id="newsDate">{news.created_at}</div>
-                            </div>
+                            {news.img_url && (
+                                <div
+                                    id="newsImg"
+                                    className="w-[200px] h-[150px] overflow-hidden flex items-center justify-center"
+                                >
+                                    <img
+                                        src={news.img_url}
+                                        alt="뉴스이미지"
+                                        className="w-full h-full object-cover object-center"
+                                    />
+                                </div>
+                            )}
                         </div>
-                        {news.img_url && (
-                            <div
-                                id="newsImg"
-                                className="w-[200px] h-[150px] overflow-hidden flex items-center justify-center"
-                            >
-                                <img
-                                    src={news.img_url}
-                                    alt="뉴스이미지"
-                                    className="w-full h-full object-cover object-center"
-                                />
-                            </div>
-                        )}
-                    </div>
-                ))}
-            </div>
+                    ))}
+                </div>
+            )}
+            {listData.length === 0 && (
+                <div className="mt-8 text-s text-dot-gray-dark flex justify-center">
+                    해당 뉴스레터가 존재하지 않습니다.
+                </div>
+            )}
         </div>
     );
 }

--- a/src/app/(user)/newsletter/page.tsx
+++ b/src/app/(user)/newsletter/page.tsx
@@ -23,6 +23,43 @@ const data = [
         category: '건강',
         user_name: '네이버 뉴스',
     },
+    {
+        news_id: '5bee582a-a4c5-4f1a-b58e-5f2eb355c228',
+        title: 'What is Lorem Ipsum?',
+        contents:
+            "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        img_url: '',
+        summary: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+        source: 'https://www.naver.com/',
+        species: '강아지',
+        like: 0,
+        share: 0,
+        is_published: true,
+        is_sended: true,
+        source_published_at: '2025.02.17 12:30',
+        created_at: '2025.02.17 12:30',
+        category: '건강',
+        user_name: '네이버 뉴스',
+    },
+    {
+        news_id: '5bee582a-a4c5-4f1a-b58e-5f2eb355c238',
+        title: 'What is Lorem Ipsum?',
+        contents:
+            "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        img_url:
+            'https://www.fitpetmall.com/wp-content/uploads/2023/10/shutterstock_1275055966-1.png',
+        summary: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+        source: 'https://www.naver.com/',
+        species: '고양이',
+        like: 0,
+        share: 0,
+        is_published: true,
+        is_sended: true,
+        source_published_at: '2025.02.17 12:30',
+        created_at: '2025.02.17 12:30',
+        category: '건강',
+        user_name: '네이버 뉴스',
+    },
 ];
 
 function NewsLetterPage() {
@@ -99,16 +136,18 @@ function NewsLetterPage() {
                                 <div id="newsDate">{news.created_at}</div>
                             </div>
                         </div>
-                        <div
-                            id="newsImg"
-                            className="w-[200px] h-[150px] overflow-hidden flex items-center justify-center"
-                        >
-                            <img
-                                src={news.img_url}
-                                alt="뉴스이미지"
-                                className="w-full h-full object-cover object-center"
-                            />
-                        </div>
+                        {news.img_url && (
+                            <div
+                                id="newsImg"
+                                className="w-[200px] h-[150px] overflow-hidden flex items-center justify-center"
+                            >
+                                <img
+                                    src={news.img_url}
+                                    alt="뉴스이미지"
+                                    className="w-full h-full object-cover object-center"
+                                />
+                            </div>
+                        )}
                     </div>
                 ))}
             </div>

--- a/src/app/(user)/newsletter/page.tsx
+++ b/src/app/(user)/newsletter/page.tsx
@@ -38,7 +38,7 @@ const data = [
         is_sended: true,
         source_published_at: '2025.02.17 12:30',
         created_at: '2025.02.17 12:30',
-        category: '건강',
+        category: '훈련',
         user_name: '네이버 뉴스',
     },
     {
@@ -65,13 +65,30 @@ const data = [
 function NewsLetterPage() {
     const [activeCategory, setActiveCategory] = useState('전체');
     const [activeSpecies, setActiveSpecies] = useState('전체');
+    const [listData, setListData] = useState(data);
+
+    const filterData = (category: string, species: string) => {
+        let filteredData = data;
+
+        if (category !== '전체') {
+            filteredData = filteredData.filter(news => news.category === category);
+        }
+
+        if (species !== '전체') {
+            filteredData = filteredData.filter(news => news.species === species);
+        }
+
+        setListData(filteredData);
+    };
 
     const onClickCategory = (category: string) => {
         setActiveCategory(category);
+        filterData(category, activeSpecies);
     };
 
     const onClickSpecies = (species: string) => {
         setActiveSpecies(species);
+        filterData(activeCategory, species);
     };
 
     return (
@@ -82,7 +99,7 @@ function NewsLetterPage() {
                         <li key={category.value} value={category.value}>
                             <button
                                 type="button"
-                                className={`hover:text-primary text-s ${
+                                className={`hover:text-primary text-s outline-none ${
                                     activeCategory === category.label
                                         ? 'text-primary font-bold'
                                         : ''
@@ -99,7 +116,7 @@ function NewsLetterPage() {
                         <li key={species.value} value={species.value}>
                             <button
                                 type="button"
-                                className={`hover:text-primary text-s ${
+                                className={`hover:text-primary text-s outline-none ${
                                     activeSpecies === species.label ? 'text-primary font-bold' : ''
                                 }`}
                                 onClick={() => onClickSpecies(species.label)}
@@ -111,10 +128,10 @@ function NewsLetterPage() {
                 </ul>
             </div>
             <div id="newContentsWrap" className="mt-4 flex flex-wrap">
-                {data.map(news => (
+                {listData.map(news => (
                     <div
                         key={news.news_id}
-                        className="w-full pb-4 mb-4 border-b border-area-gray flex justify-between"
+                        className="w-full pb-4 mb-4 border-b border-area-gray flex justify-between h-[150px]"
                     >
                         <div
                             id="newsText"

--- a/src/app/(user)/newsletter/page.tsx
+++ b/src/app/(user)/newsletter/page.tsx
@@ -3,6 +3,28 @@
 import { categoryOptions, speciesOptions } from '@/app/admin/newsletter/collect/page';
 import React, { useState } from 'react';
 
+const data = [
+    {
+        news_id: '5bee582a-a4c5-4f1a-b58e-5f2eb355c218',
+        title: 'What is Lorem Ipsum?',
+        contents:
+            "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        img_url:
+            'https://hips.hearstapps.com/hmg-prod/images/dog-puppy-on-garden-royalty-free-image-1586966191.jpg?crop=0.752xw:1.00xh;0.175xw,0&resize=1200:*',
+        summary: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+        source: 'https://www.naver.com/',
+        species: '강아지',
+        like: 0,
+        share: 0,
+        is_published: true,
+        is_sended: true,
+        source_published_at: '2025.02.17 12:30',
+        created_at: '2025.02.17 12:30',
+        category: '건강',
+        user_name: '네이버 뉴스',
+    },
+];
+
 function NewsLetterPage() {
     const [activeCategory, setActiveCategory] = useState('전체');
     const [activeSpecies, setActiveSpecies] = useState('전체');
@@ -51,7 +73,45 @@ function NewsLetterPage() {
                     ))}
                 </ul>
             </div>
-            <div id="newContentsWrap" className="mt-4 flex flex-wrap" />
+            <div id="newContentsWrap" className="mt-4 flex flex-wrap">
+                {data.map(news => (
+                    <div
+                        key={news.news_id}
+                        className="w-full pb-4 mb-4 border-b border-area-gray flex justify-between"
+                    >
+                        <div
+                            id="newsText"
+                            className={`${news.img_url ? 'w-4/5' : 'w-full'} flex flex-col justify-around`}
+                        >
+                            <div id="newsSource" className="text-xs text-dot-gray-dark">
+                                {news.user_name}
+                            </div>
+                            <div id="newsTitle" className="font-bold">
+                                {news.title}
+                            </div>
+                            <div
+                                id="newsContents"
+                                className="text-s text-dot-gray-dark2 line-clamp-2"
+                            >
+                                {news.contents}
+                            </div>
+                            <div id="newsBottomWrap" className="text-s text-dot-gray-dark">
+                                <div id="newsDate">{news.created_at}</div>
+                            </div>
+                        </div>
+                        <div
+                            id="newsImg"
+                            className="w-[200px] h-[150px] overflow-hidden flex items-center justify-center"
+                        >
+                            <img
+                                src={news.img_url}
+                                alt="뉴스이미지"
+                                className="w-full h-full object-cover object-center"
+                            />
+                        </div>
+                    </div>
+                ))}
+            </div>
         </div>
     );
 }

--- a/src/app/(user)/newsletter/page.tsx
+++ b/src/app/(user)/newsletter/page.tsx
@@ -1,7 +1,59 @@
-import React from 'react';
+'use client';
+
+import { categoryOptions, speciesOptions } from '@/app/admin/newsletter/collect/page';
+import React, { useState } from 'react';
 
 function NewsLetterPage() {
-    return <div>newsletter</div>;
+    const [activeCategory, setActiveCategory] = useState('전체');
+    const [activeSpecies, setActiveSpecies] = useState('전체');
+
+    const onClickCategory = (category: string) => {
+        setActiveCategory(category);
+    };
+
+    const onClickSpecies = (species: string) => {
+        setActiveSpecies(species);
+    };
+
+    return (
+        <div>
+            <div id="filterWrap">
+                <ul id="categoryFilter" className="flex gap-20">
+                    {categoryOptions.map(category => (
+                        <li key={category.value} value={category.value}>
+                            <button
+                                type="button"
+                                className={`hover:text-primary text-s ${
+                                    activeCategory === category.label
+                                        ? 'text-primary font-bold'
+                                        : ''
+                                }`}
+                                onClick={() => onClickCategory(category.label)}
+                            >
+                                {category.label}
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+                <ul id="speciesFilter" className="mt-2 flex gap-20">
+                    {speciesOptions.map(species => (
+                        <li key={species.value} value={species.value}>
+                            <button
+                                type="button"
+                                className={`hover:text-primary text-s ${
+                                    activeSpecies === species.label ? 'text-primary font-bold' : ''
+                                }`}
+                                onClick={() => onClickSpecies(species.label)}
+                            >
+                                {species.label}
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+            <div id="newContentsWrap" className="mt-4 flex flex-wrap" />
+        </div>
+    );
 }
 
 export default NewsLetterPage;

--- a/src/app/(user)/newsletter/page.tsx
+++ b/src/app/(user)/newsletter/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { categoryOptions, speciesOptions } from '@/app/admin/newsletter/collect/page';
+import Link from 'next/link';
 import React, { useState } from 'react';
 
 const data = [
@@ -18,8 +19,8 @@ const data = [
         share: 0,
         is_published: true,
         is_sended: true,
-        source_published_at: '2025.02.17 12:30',
-        created_at: '2025.02.17 12:30',
+        source_published_at: '2025.02.17 12:30:10',
+        created_at: '2025.02.17 12:40:10',
         category: '건강',
         user_name: '네이버 뉴스',
     },
@@ -36,8 +37,8 @@ const data = [
         share: 0,
         is_published: true,
         is_sended: true,
-        source_published_at: '2025.02.17 12:30',
-        created_at: '2025.02.17 12:30',
+        source_published_at: '2025.02.17 12:30:20',
+        created_at: '2025.02.17 12:40:20',
         category: '훈련',
         user_name: '네이버 뉴스',
     },
@@ -55,8 +56,8 @@ const data = [
         share: 0,
         is_published: true,
         is_sended: true,
-        source_published_at: '2025.02.17 12:30',
-        created_at: '2025.02.17 12:30',
+        source_published_at: '2025.02.17 12:30:30',
+        created_at: '2025.02.17 12:40:00',
         category: '건강',
         user_name: '네이버 뉴스',
     },
@@ -132,40 +133,45 @@ function NewsLetterPage() {
                     {listData.map(news => (
                         <div
                             key={news.news_id}
-                            className="w-full pb-4 mb-4 border-b border-area-gray flex justify-between h-[150px]"
+                            className="w-full mb-4 pb-4 border-b border-area-gray flex justify-between h-[150px]"
                         >
-                            <div
-                                id="newsText"
-                                className={`${news.img_url ? 'w-4/5' : 'w-full'} flex flex-col justify-around`}
+                            <Link
+                                className="w-full flex justify-between"
+                                href={`/newsletter/${news.news_id}`}
                             >
-                                <div id="newsSource" className="text-xs text-dot-gray-dark">
-                                    {news.user_name}
-                                </div>
-                                <div id="newsTitle" className="font-bold">
-                                    {news.title}
-                                </div>
                                 <div
-                                    id="newsContents"
-                                    className="text-s text-dot-gray-dark2 line-clamp-2"
+                                    id="newsText"
+                                    className={`${news.img_url ? 'w-4/5' : 'w-full'} flex flex-col justify-around`}
                                 >
-                                    {news.contents}
+                                    <div id="newsSource" className="text-xs text-dot-gray-dark">
+                                        {news.user_name}
+                                    </div>
+                                    <div id="newsTitle" className="font-bold">
+                                        {news.title}
+                                    </div>
+                                    <div
+                                        id="newsContents"
+                                        className="text-s text-dot-gray-dark2 line-clamp-2"
+                                    >
+                                        {news.contents}
+                                    </div>
+                                    <div id="newsBottomWrap" className="text-s text-dot-gray-dark">
+                                        <div id="newsDate">{news.created_at}</div>
+                                    </div>
                                 </div>
-                                <div id="newsBottomWrap" className="text-s text-dot-gray-dark">
-                                    <div id="newsDate">{news.created_at}</div>
-                                </div>
-                            </div>
-                            {news.img_url && (
-                                <div
-                                    id="newsImg"
-                                    className="w-[200px] h-[150px] overflow-hidden flex items-center justify-center"
-                                >
-                                    <img
-                                        src={news.img_url}
-                                        alt="뉴스이미지"
-                                        className="w-full h-full object-cover object-center"
-                                    />
-                                </div>
-                            )}
+                                {news.img_url && (
+                                    <div
+                                        id="newsImg"
+                                        className="w-[200px] h-[130px] overflow-hidden flex items-center justify-center"
+                                    >
+                                        <img
+                                            src={news.img_url}
+                                            alt="뉴스이미지"
+                                            className="w-full h-full object-cover object-center"
+                                        />
+                                    </div>
+                                )}
+                            </Link>
                         </div>
                     ))}
                 </div>

--- a/src/app/(user)/newsletter/page.tsx
+++ b/src/app/(user)/newsletter/page.tsx
@@ -4,7 +4,7 @@ import { categoryOptions, speciesOptions } from '@/app/admin/newsletter/collect/
 import Link from 'next/link';
 import React, { useState } from 'react';
 
-const data = [
+export const data = [
     {
         news_id: '5bee582a-a4c5-4f1a-b58e-5f2eb355c218',
         title: 'What is Lorem Ipsum?',

--- a/src/app/(user)/newsletter/page.tsx
+++ b/src/app/(user)/newsletter/page.tsx
@@ -2,6 +2,7 @@
 
 import { categoryOptions, speciesOptions } from '@/app/admin/newsletter/collect/page';
 import Link from 'next/link';
+import { Heart, Share } from 'lucide-react';
 import React, { useState } from 'react';
 
 export const data = [
@@ -15,12 +16,12 @@ export const data = [
         summary: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
         source: 'https://www.naver.com/',
         species: '강아지',
-        like: 0,
-        share: 0,
+        like: 10,
+        share: 20,
         is_published: true,
         is_sended: true,
         source_published_at: '2025.02.17 12:30:10',
-        created_at: '2025.02.17 12:40:10',
+        created_at: '2025.02.18 23:53:10',
         category: '건강',
         user_name: '네이버 뉴스',
     },
@@ -92,6 +93,24 @@ function NewsLetterPage() {
         filterData(activeCategory, species);
     };
 
+    const onClickLikeBtn = () => {
+        console.log('like');
+    };
+
+    // const onClickBookmarkBtn = () => {
+    //     console.log('bookmark');
+    // };
+
+    const onClickShareBtn = () => {
+        console.log('share');
+    };
+
+    const isLiked = (newsId: string) => {
+        if (newsId) return false;
+
+        return false;
+    };
+
     return (
         <div>
             <div id="filterWrap">
@@ -155,8 +174,41 @@ function NewsLetterPage() {
                                     >
                                         {news.contents}
                                     </div>
-                                    <div id="newsBottomWrap" className="text-s text-dot-gray-dark">
+                                    <div
+                                        id="newsBottomWrap"
+                                        className="flex text-s text-dot-gray-dark items-center"
+                                    >
                                         <div id="newsDate">{news.created_at}</div>
+                                        <div className="flex gap-4 ml-4">
+                                            <div className="flex gap-1 items-center text-secondary">
+                                                <button
+                                                    type="button"
+                                                    onClick={onClickLikeBtn}
+                                                    className="outline-none"
+                                                >
+                                                    <Heart
+                                                        className={`w-4 ${isLiked(news.news_id) ? 'fill-current' : ''}`}
+                                                    />
+                                                </button>
+                                                <div>{news.like}</div>
+                                            </div>
+                                            {/* <div className="flex gap-1 items-center text-secondary">
+                                                <button type="button" onClick={onClickBookmarkBtn} className="outline-none">
+                                                    <Bookmark className={`w-4 ${news.isBookmarked ? 'fill-current' : ''}`} />
+                                                </button>
+                                                <div>{news.bookmark}</div>
+                                            </div> */}
+                                            <div className="flex gap-1 items-center text-secondary">
+                                                <button
+                                                    type="button"
+                                                    onClick={onClickShareBtn}
+                                                    className="outline-none"
+                                                >
+                                                    <Share className="w-4" />
+                                                </button>
+                                                <div>{news.share}</div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                                 {news.img_url && (

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -43,7 +43,7 @@ const items = [
         url: '/admin/newsletter',
         icon: Newspaper,
         subItems: [
-            { title: '목록', url: '#' },
+            { title: '목록', url: '/newsletter' },
             { title: '수집', url: '/admin/newsletter/collect' },
             { title: '게시 및 발송', url: '#' },
         ],


### PR DESCRIPTION
## #️⃣ 이슈 번호
#89 

## 📝 요약
- 뉴스레터 목록 조회 페이지 마크업
- 상세 페이지 마크업

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [x] UI 디자인 변경
-   [ ] 코드 리팩토링
-   [ ] 문서 수정
-   [ ] 기타 (설명해주세요)

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/534dc8a8-cefb-43ff-a726-c1bab94eac28)
---
![image](https://github.com/user-attachments/assets/d9a6ddfe-4b92-4cd6-b30a-8d9066715785)
![image](https://github.com/user-attachments/assets/24a24322-ad00-4d5e-b924-cb9389576cdf)


## 💬 작업 중 궁금했던 사항
- 왜 `카테고리`는 따로 테이블이 있는데 `종`은 따로 테이블이 없는지?
- 카테고리와 종의 각 내용이 db에 `한글`로 입력되는지 `영어`로 입력되는 건지(**cat**인지 **고양이**인지)
- 만약 네이버 뉴스일 경우 `news_items의 user_id`는 어떻게 들어가는지
- `좋아요` 랑 `북마크` 의 차이는?

## ✅ PR 체크리스트

-   [ ] 커밋 메시지 컨벤션을 따랐습니다.
-   [ ] 변경 사항에 대한 테스트를 수행했습니다.
-   [ ] 관련 문서를 업데이트했습니다.
